### PR TITLE
retries for failed apicalls, updated usages count in metering to 10 and more

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-02T05:59:47Z",
+  "generated_at": "2022-04-05T06:11:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,7 +76,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.47.dss",
+  "version": "0.13.1+ibm.48.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Instrument your applications with App Configuration Java SDK, and use the App Co
 <dependency>
     <groupId>com.ibm.cloud</groupId>
     <artifactId>appconfiguration-java-sdk</artifactId>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```sh
-implementation group: 'com.ibm.cloud', name: 'appconfiguration-java-sdk', version: '0.2.3'
+implementation group: 'com.ibm.cloud', name: 'appconfiguration-java-sdk', version: '0.2.4'
 ```
 
 ## Import the SDK
@@ -44,7 +44,7 @@ import com.ibm.cloud.appconfiguration.sdk.AppConfiguration;
 ## Initialize SDK
 
 ```java
-String region = "region";
+String region = AppConfiguration.REGION_US_SOUTH;
 String guid = "guid";
 String apikey = "apikey";
 
@@ -58,8 +58,8 @@ appConfigClient.setContext(collectionId, environmentId);
 :red_circle: **Important** :red_circle:
 
 The **`init()`** and **`setContext()`** are the initialisation methods and should be invoked **only once** using
-appConfigClient. The appConfigClient, once initialised, can be obtained across modules
-using **`AppConfiguration.getInstance()`**.  [See this example below](#fetching-the-appconfigclient-across-other-modules).
+appConfigClient. The appConfigClient, once initialised, can be obtained across classes.
+using **`AppConfiguration.getInstance()`**.  [See this example below](#fetching-the-appConfigClient-across-other-classes).
 
 - region : Region name where the service instance is created. Use
     - `AppConfiguration.REGION_US_SOUTH` for Dallas
@@ -92,16 +92,17 @@ Please ensure that the cache file is not lost or deleted in any case. For exampl
 
 
 ### (Optional)
-The SDK is also designed to serve configurations, perform feature flag & property evaluations without being connected to App Configuration service.
+The SDK is also designed to serve configurations, and perform feature flag & property evaluations without being connected to App Configuration service.
 
 ```java
 ConfigurationOptions configOptions = new ConfigurationOptions();
 configOptions.setBootstrapFile("saflights/flights.json");
 configOptions.setLiveConfigUpdateEnabled(false);
+appConfigClient.setContext(collectionId, environmentId, configOptions);
 ```
 
 - bootstrapFile: Absolute path of the JSON file, which contains configuration details. Make sure to provide a proper JSON file. You can generate this file using `ibmcloud ac config` command of the IBM Cloud App Configuration CLI.
-- liveConfigUpdateEnabled: Live configuration update from the server. Set this value to `false` if the new configuration values shouldn't be fetched from the server.
+- liveConfigUpdateEnabled: Live configuration update from the server. Set this value to `false` if the new configuration values must not be fetched from the server. By default, this value is set to `true`.
 
 
 ## Get single feature
@@ -109,7 +110,7 @@ configOptions.setLiveConfigUpdateEnabled(false);
 ```java
 Feature feature = appConfigClient.getFeature("online-check-in");
 
-if (feature) {
+if (feature != null) {
     System.out.println("Feature Name : " + feature.getFeatureName());
     System.out.println("Feature Id : " + feature.getFeatureId());
     System.out.println("Feature Type : " + feature.getFeatureDataType());
@@ -144,7 +145,7 @@ String value = (String) feature.getCurrentValue(entityId, entityAttributes);
 ```java
 Property property = appConfigClient.getProperty("check-in-charges");
 
-if (property) {
+if (property != null) {
     System.out.println("Property Name : " + property.getPropertyName());
     System.out.println("Property Id : " + property.getPropertyId());
     System.out.println("Property Type : " + property.getPropertyDataType());
@@ -173,12 +174,12 @@ entityAttributes.put("country", "India");
 String value = (String) property.getCurrentValue(entityId, entityAttributes);
 ```
 
-## Fetching the appConfigClient across other modules
+## Fetching the appConfigClient across other classes
 
-Once the SDK is initialized, the appConfigClient can be obtained across other modules as shown below:
+Once the SDK is initialized, the appConfigClient can be obtained across other classes as shown below:
 
 ```java
-// **other modules**
+// **other classes**
 
 import com.ibm.cloud.appconfiguration.sdk.AppConfiguration;
 AppConfiguration appConfigClient = AppConfiguration.getInstance();
@@ -242,9 +243,9 @@ if (feature != null) {
 ```java
 Property property = appConfigClient.getProperty("json-property");
 if (property != null) {
-    property.getPropertyDataType()     // STRING
-    property.getPropertyDataFormat()   // JSON
-    property.getCurrentValue(entityId, entityAttributes) // JSONObject or JSONArray is returned
+    property.getPropertyDataType();     // STRING
+    property.getPropertyDataFormat();   // JSON
+    property.getCurrentValue(entityId, entityAttributes); // JSONObject or JSONArray is returned
 
 }
 
@@ -263,9 +264,9 @@ String expected_output = (String) tar_val.get('role');
 
 Property property = appConfigClient.getProperty("yaml-property");
 if (property != null) {
-    property.getPropertyDataType()     // STRING
-    property.getPropertyDataFormat()   // YAML
-    property.getCurrentValue(entityId, entityAttributes) // Yaml String is returned
+    property.getPropertyDataType();     // STRING
+    property.getPropertyDataFormat();   // YAML
+    property.getCurrentValue(entityId, entityAttributes); // Yaml String is returned
 
 }
 ```

--- a/ibm-appconfiguration/pom.xml
+++ b/ibm-appconfiguration/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>appconfiguration-java-sdk</artifactId>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <packaging>jar</packaging>
 
     <name>IBM Cloud App Configuration Java server SDK</name>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.ibm.cloud</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>9.14.0</version>
+            <version>9.16.1</version>
         </dependency>
       </dependencies>
 

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/AppConfiguration.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/AppConfiguration.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
  * Toggle feature flag states in the cloud to activate or deactivate features in your application or
  * environment, when required. You can also manage the properties for distributed applications centrally.
  *
- * @version 0.2.3
+ * @version 0.2.4
  * @see <a href="https://cloud.ibm.com/docs/app-configuration">App Configuration</a>
  */
 public class AppConfiguration {

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/ConfigConstants.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/ConfigConstants.java
@@ -28,7 +28,7 @@ public class ConfigConstants {
     public static final String DEFAULT_HTTP_TYPE = "https://";
     public static final String DEFAULT_WSS_TYPE = "wss://";
     public static final String DEFAULT_BASE_URL = ".apprapp.cloud.ibm.com";
-    public static final int DEFAULT_USAGE_LIMIT = 25;
+    public static final int DEFAULT_USAGE_LIMIT = 10;
     public static final String DEFAULT_SERVICE_NAME = "app_configuration";
     public static final String PROPERTIES = "properties";
     public static final String SEGMENTS = "segments";

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/ConfigMessages.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/ConfigMessages.java
@@ -40,4 +40,6 @@ public class ConfigMessages {
     public static final String CONFIG_API_ERROR = "Invalid configuration. Verify the collectionId, environmentId, apikey, guid and region.";
     public static final String FEATURE_INVALID = "Invalid featureId - ";
     public static final String PROPERTY_INVALID = "Invalid propertyId - ";
+    public static final String FETCH_API_SUCCESSFUL = "Successfully fetched the configurations.";
+    public static final String API_RETRY_SCHEDULED_MESSAGE = "Scheduled the API request to retry after 10 minutes.";
 }

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/Connectivity.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/Connectivity.java
@@ -30,10 +30,12 @@ public class Connectivity {
 
     private static Connectivity instance;
     private List<ConnectivityListener> listeners = new ArrayList<>();
+    private final String className = this.getClass().getName();
 
     public static synchronized Connectivity getInstance() {
         if (instance == null) {
             instance = new Connectivity();
+            instance.checkConnection();
             instance.start();
         }
         return instance;
@@ -58,20 +60,21 @@ public class Connectivity {
      * Check the internet connection by making ping to <a href="https://cloud.ibm.com">https://cloud.ibm.com</a>.
      */
     public void checkConnection() {
-        Boolean connected = false;
+        boolean connected = false;
         Socket socket = new Socket();
+        String methodName = "checkConnection";
         try {
             InetSocketAddress address = new InetSocketAddress("cloud.ibm.com", 80);
-            socket.connect(address, 500);
+            socket.connect(address, 5000);
             connected = socket.isConnected();
         } catch (Exception e) {
-            AppConfigException.logException(this.getClass().getName(), "checkConnection", e,
+            AppConfigException.logException(this.className, methodName, e,
                                             new Object[] {"Exception in checking network connection."});
         } finally {
             try {
                 socket.close();
             } catch (Exception e) {
-                AppConfigException.logException(this.getClass().getName(), "checkConnection", e,
+                AppConfigException.logException(this.className, methodName, e,
                                                 new Object[] {"Exception in closing network connection."});
             }
         }

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/RetryHandler.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/RetryHandler.java
@@ -48,7 +48,7 @@ public class RetryHandler {
                 retryInterface.retryMethod();
             }
         };
-        this.retryTimer = new Timer();
+        this.retryTimer = new Timer(true);
         this.retryTimer.scheduleAtFixedRate(task, this.retryInterval, this.retryInterval);
     }
 

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/Socket.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/internal/Socket.java
@@ -57,8 +57,12 @@ public class Socket extends WebSocketClient {
 
     @Override
     public void onClose(int code, String reason, boolean remote) {
-        this.listener.onClose("Connection closed by " + (remote ? "remote peer" : "us") + " Code: " + code
-                                + " Reason: " + reason);
+        if (remote) {
+            this.listener.onClose("Connection closed by remote host. " + " Code: " + code + " Reason: " + reason);
+        } else {
+            // Don't to anything as it maybe the intentional close initiated by the client
+            BaseLogger.debug("Connection closed by client. " + " Code: " + code + " Reason: " + reason);
+        }
     }
 
     @Override

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/models/internal/Rule.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/models/internal/Rule.java
@@ -28,6 +28,7 @@ public class Rule {
     public String attributeName;
     public String operator;
     public JSONArray values;
+    private final String className = this.getClass().getName();
 
     /**
      * @param ruleJson JSON object containing rule information
@@ -39,7 +40,7 @@ public class Rule {
             this.operator = ruleJson.getString("operator");
             this.values = ruleJson.getJSONArray("values");
         } catch (Exception e) {
-            AppConfigException.logException("Rule", "Constructor", e, new Object[] { "Invalid action in Rule class."});
+            AppConfigException.logException(this.className, "Constructor", e, new Object[] { "Invalid action in Rule class."});
 
         }
     }
@@ -55,12 +56,13 @@ public class Rule {
 
         Boolean result = false;
         Object key;
+        String methodName = "evaluateRule";
 
         if (entityAttributes.has(this.attributeName)) {
             try {
                 key = entityAttributes.get(this.attributeName);
             } catch (Exception e) {
-                AppConfigException.logException(this.getClass().getName(), "evaluateRule", e);
+                AppConfigException.logException(this.className, methodName, e);
                 return result;
             }
         } else {
@@ -75,7 +77,7 @@ public class Rule {
                 }
 
             } catch (Exception e) {
-                AppConfigException.logException(this.getClass().getName(), "evaluateRule", e);
+                AppConfigException.logException(this.className, methodName, e);
                 return result;
             }
         }
@@ -111,7 +113,7 @@ public class Rule {
                     try {
                         result = value.toString().equals(key.toString());
                     } catch (Exception e) {
-                        AppConfigException.logException(this.getClass().getName(), "is", e);
+                        AppConfigException.logException(this.className, "is", e);
                     }
                 }
                 break;
@@ -161,7 +163,7 @@ public class Rule {
                 return new Conversions(true, keyValue);
             }
         } catch (Exception e) {
-            AppConfigException.logException(this.getClass().getName(), "numberConversion", e);
+            AppConfigException.logException(this.className, "numberConversion", e);
         }
         return new Conversions(false, Float.valueOf(0));
 

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/models/internal/Segment.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/configurations/models/internal/Segment.java
@@ -29,6 +29,7 @@ public class Segment {
     String name;
     String segmentId;
     JSONArray rules;
+    private final String className = this.getClass().getName();
 
     /**
      * @param segmentJson segments JSON object that contains all the segments
@@ -40,7 +41,7 @@ public class Segment {
             this.rules = segmentJson.getJSONArray(ConfigConstants.RULES);
 
         } catch (Exception e) {
-            AppConfigException.logException(this.getClass().getName(), "Segment.init", e,
+            AppConfigException.logException(this.className, "Segment.init", e,
                                             new Object[] {"Invalid action in Segment class. "});
         }
     }
@@ -81,7 +82,7 @@ public class Segment {
                     return false;
                 }
             } catch (Exception e) {
-                AppConfigException.logException(this.getClass().getName(), "evaluateRule", e,
+                AppConfigException.logException(this.className, "evaluateRule", e,
                                                 new Object[] {"Invalid action in Segment class."});
             }
         }

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/AppConfigException.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/AppConfigException.java
@@ -46,6 +46,6 @@ public final class AppConfigException {
         for (int i = messageParams.length - 1; i >= 0; i--) {
             message += messageParams[i];
         }
-        BaseLogger.debug(message);
+        BaseLogger.error(message);
     }
 }

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/CoreConstants.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/CoreConstants.java
@@ -24,8 +24,14 @@ public class CoreConstants {
     private CoreConstants() { }
 
     public static final Integer REQUEST_SUCCESS_200 = 200;
+    public static final Integer REQUEST_SUCCESS_202 = 202;
     public static final Integer REQUEST_SUCCESS_299 = 299;
     public static final Integer REQUEST_ERROR_AUTH = 401;
     public static final Integer REQUEST_ERROR = 400;
+    public static final Integer TOO_MANY_REQUESTS = 429;
     public static final Integer REQUEST_ERROR_NOT_SUPPORTED = 405;
+    public static final Integer SERVER_ERROR_BEGIN = 500;
+    public static final Integer SERVER_ERROR_END = 599;
+    public static final Integer MAX_NO_OF_RETRIES = 3;
+    public static final Integer MAX_RETRY_INTERVAL = 30; // (in seconds) The maximum interval between two successive retry attempts
 }

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/ServiceImpl.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/core/ServiceImpl.java
@@ -77,6 +77,7 @@ public class ServiceImpl extends BaseService {
         ServiceImpl.overrideServerHost = overrideServerHost;
         IamAuthenticator iamAuthenticator = ServiceImpl.getIamAuthenticator();
         ServiceImpl service = new ServiceImpl(ConfigConstants.DEFAULT_SERVICE_NAME, iamAuthenticator);
+        service.enableRetries(CoreConstants.MAX_NO_OF_RETRIES, CoreConstants.MAX_RETRY_INTERVAL);
         service.configureService(ConfigConstants.DEFAULT_SERVICE_NAME);
         return service;
     }
@@ -155,18 +156,12 @@ public class ServiceImpl extends BaseService {
      * @return the HTTP response
      */
     public Response getConfig(String url) {
-        try {
-            RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(url, null, null));
-            for (Map.Entry<String, String> header : this.getServiceHeaders().entrySet()) {
-                builder.header(header.getKey(), header.getValue());
-            }
-
-            ResponseConverter<String> responseConverter = ResponseConverterUtils.getString();
-            return createServiceCall(builder.build(), responseConverter).execute();
-        } catch (Exception e) {
-            BaseLogger.error(e.getLocalizedMessage());
+        RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(url, null, null));
+        for (Map.Entry<String, String> header : this.getServiceHeaders().entrySet()) {
+            builder.header(header.getKey(), header.getValue());
         }
-        return null;
+        ResponseConverter<String> responseConverter = ResponseConverterUtils.getString();
+        return createServiceCall(builder.build(), responseConverter).execute();
     }
 
     /**
@@ -177,19 +172,13 @@ public class ServiceImpl extends BaseService {
      * @return the HTTP response
      */
     public Response postMetering(String meteringUrl, JSONObject data) {
-        try {
-            RequestBuilder builder = RequestBuilder.
-            post(RequestBuilder.resolveRequestUrl(meteringUrl, null, null));
-            for (Map.Entry<String, String> header : this.getServiceHeaders().entrySet()) {
-                builder.header(header.getKey(), header.getValue());
-            }
-            JsonObject jsonData = new Gson().fromJson(String.valueOf(data), JsonObject.class);
-            builder.bodyJson(jsonData);
-            ResponseConverter<String> responseConverter = ResponseConverterUtils.getString();
-            return createServiceCall(builder.build(), responseConverter).execute();
-        } catch (Exception e) {
-            BaseLogger.error(e.getLocalizedMessage());
+        RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(meteringUrl, null, null));
+        for (Map.Entry<String, String> header : this.getServiceHeaders().entrySet()) {
+            builder.header(header.getKey(), header.getValue());
         }
-        return null;
+        JsonObject jsonData = new Gson().fromJson(String.valueOf(data), JsonObject.class);
+        builder.bodyJson(jsonData);
+        ResponseConverter<String> responseConverter = ResponseConverterUtils.getString();
+        return createServiceCall(builder.build(), responseConverter).execute();
     }
 }

--- a/ibm-appconfiguration/src/test/java/com/ibm/cloud/appconfiguration/sdk/test/core/ServiceImplTest.java
+++ b/ibm-appconfiguration/src/test/java/com/ibm/cloud/appconfiguration/sdk/test/core/ServiceImplTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,11 +38,15 @@ public class ServiceImplTest {
         assertNotEquals(ServiceImpl.getCurrentDateTime(), String.valueOf(Instant.now()),
             "These two values are not equal");
 
-        assertEquals("0.2.3", ServiceImpl.getVersion(), "version are same in pom.xml");
+        assertEquals("0.2.4", ServiceImpl.getVersion(), "version are same in pom.xml");
         assertEquals("appconfiguration-java-sdk", ServiceImpl.getArtifactId(), "Artifact Id are same");
 
         ServiceImpl test = ServiceImpl.getInstance("apikey", "test");
-        assertNull(test.getConfig("http://testConfig"));
-        assertNull(test.postMetering("http://testMetering", new JSONObject()));
+        assertThrows(Exception.class, () -> {
+            test.getConfig("http://testConfig");
+        });
+        assertThrows(Exception.class, () -> {
+            test.postMetering("http://testMetering", new JSONObject());
+        });
     }
 }


### PR DESCRIPTION
- enabled retries for failed API calls
- usages array length updated to 10 per API request payload
- incase of server errors metering data is resubmitted until it is accepted
- internet connectivity-check thread is made to run as daemon thread (previously it was running as non-daemon thread and was blocking the main thread from exit)
- timeout for internet connection-check increased from 0.5 second to 5 seconds (there might be false positives during poor network connection)
- refactored few lines that follows best practises of coding
- dependency version update
- patch version updated to 0.2.4