### PR TITLE
add support for eu-de region

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 repos:
 - repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
   # If you desire to use a specific version of whitewater-detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-  rev: 0.13.1+ibm.61.dss
+  rev: 0.13.1+ibm.62.dss
   hooks:
     -   id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-25T06:11:41Z",
+  "generated_at": "2024-03-16T19:18:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -61,7 +61,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Instrument your applications with App Configuration Java SDK, and use the App Co
 <dependency>
     <groupId>com.ibm.cloud</groupId>
     <artifactId>appconfiguration-java-sdk</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```sh
-implementation group: 'com.ibm.cloud', name: 'appconfiguration-java-sdk', version: '0.3.5'
+implementation group: 'com.ibm.cloud', name: 'appconfiguration-java-sdk', version: '0.3.6'
 ```
 
 ## Import the SDK
@@ -66,6 +66,7 @@ using **`AppConfiguration.getInstance()`**.  [See this example below](#fetching-
     - `AppConfiguration.REGION_EU_GB` for London
     - `AppConfiguration.REGION_AU_SYD` for Sydney
     - `AppConfiguration.REGION_US_EAST` for Washington DC
+    - `AppConfiguration.REGION_EU_DE` for Frankfurt
 - guid : GUID of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - apikey : ApiKey of the App Configuration service. Get it from the service instance credentials section of the dashboard
 - collectionId : Id of the collection created in App Configuration service instance under the **Collections** section.

--- a/ibm-appconfiguration/.secrets.baseline
+++ b/ibm-appconfiguration/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-11-10T09:43:53Z",
+  "generated_at": "2024-03-13T10:23:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -65,7 +65,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.55.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/ibm-appconfiguration/pom.xml
+++ b/ibm-appconfiguration/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ibm.cloud</groupId>
     <artifactId>appconfiguration-java-sdk</artifactId>
-    <version>0.3.5</version>
+    <version>0.3.6</version>
     <packaging>jar</packaging>
 
     <name>IBM Cloud App Configuration Java server SDK</name>

--- a/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/AppConfiguration.java
+++ b/ibm-appconfiguration/src/main/java/com/ibm/cloud/appconfiguration/sdk/AppConfiguration.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
  * Toggle feature flag states in the cloud to activate or deactivate features in your application or
  * environment, when required. You can also manage the properties for distributed applications centrally.
  *
- * @version 0.3.5
+ * @version 0.3.6
  * @see <a href="https://cloud.ibm.com/docs/app-configuration">App Configuration</a>
  */
 public class AppConfiguration {
@@ -46,6 +46,7 @@ public class AppConfiguration {
     public static final String REGION_EU_GB = "eu-gb";
     public static final String REGION_AU_SYD = "au-syd";
     public static final String REGION_US_EAST = "us-east";
+    public static final String REGION_EU_DE = "eu-de";
     private static String overrideServiceUrl = null;
     private String apiKey = "";
     private String region = "";

--- a/ibm-appconfiguration/src/test/java/com/ibm/cloud/appconfiguration/sdk/test/core/ServiceImplTest.java
+++ b/ibm-appconfiguration/src/test/java/com/ibm/cloud/appconfiguration/sdk/test/core/ServiceImplTest.java
@@ -38,7 +38,7 @@ public class ServiceImplTest {
         assertNotEquals(ServiceImpl.getCurrentDateTime(), String.valueOf(Instant.now()),
             "These two values are not equal");
 
-        assertEquals("0.3.5", ServiceImpl.getVersion(), "version are same in pom.xml");
+        assertEquals("0.3.6", ServiceImpl.getVersion(), "version are same in pom.xml");
         assertEquals("appconfiguration-java-sdk", ServiceImpl.getArtifactId(), "Artifact Id are same");
 
         ServiceImpl test = ServiceImpl.getInstance("apikey");


### PR DESCRIPTION
- add SDK support for IBM Cloud region - `eu-de`
- bump SDK patch version. SDK new version is v0.3.6